### PR TITLE
fix error when host not found

### DIFF
--- a/functions.py
+++ b/functions.py
@@ -46,6 +46,9 @@ def nmap_ports_stats(scanfile):
 
 	po,pc,pf = 0,0,0
 
+	if 'host' not in o:
+		return {'po':0,'pc':0,'pf':0}
+
 	for ik in o['host']:
 		if type(ik) is dict:
 			i = ik


### PR DESCRIPTION
fix error on `nmap_ports_stats()` when scanfile doesn't contains any host.