### PR TITLE
Pinning versions for pip3

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,7 +28,7 @@ RUN mkdir /opt/xml && mkdir /opt/notes && \
     wget -P /opt/ https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.4/wkhtmltox-0.12.4_linux-generic-amd64.tar.xz && \
     cd /opt/ && tar -xvf /opt/wkhtmltox-0.12.4_linux-generic-amd64.tar.xz
 
-RUN pip3 install Django requests xmltodict && \
+RUN pip3 install Django==2.1.5 requests==2.21.0 xmltodict==0.11.0 && \
     cd /opt/ && django-admin startproject nmapdashboard && cd /opt/nmapdashboard && \
     git clone https://github.com/Rev3rseSecurity/WebMap.git nmapreport && \
     cd nmapreport && git checkout v2.3/master

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-requests
-xmltodict
-python-nmap
+Django==2.1.5
+python-nmap==0.6.1
+requests==2.21.0
+xmltodict==0.11.0


### PR DESCRIPTION
* Pin the version for pip libraries - sometimes libraries will update something and break your code.  It's hard to figure out why if you just have it pull the latest version.
* Not sure if they are installed as part of `requirements.txt` or in `Dockerfile`, so I updated both.
* If `python-nmap` isn't used, it can be removed from the `requirements.txt` file